### PR TITLE
Local registry as reference setup for portable Knative build templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,7 @@ Self-hosting is achievable with [Minio](https://minio.io/) and the [s3](https://
 
 A compelling advantage with S3 or GCS bucket stores is that you can reuse the same bucket across clusters,
 getting access to the same images everywhere.
+
+## On minikube
+
+Run `minikube ssh` followed by `echo "127.0.0.1 knative-local-registry" | sudo tee -a /etc/hosts`.

--- a/templates/localhost-proxy-config.yaml
+++ b/templates/localhost-proxy-config.yaml
@@ -1,0 +1,55 @@
+kind: ConfigMap
+metadata:
+  name: localhost-proxy
+  namespace: registry
+apiVersion: v1
+data:
+  nginx.conf: |
+    events {
+        worker_connections  10;
+    }
+
+    http {
+
+      upstream docker-registry {
+        # Proxy to non-tls because this is only meant for localhost:5000/... registry access
+        server unauthenticated:80;
+      }
+
+      ## Set a variable to help us decide if we need to add the
+      ## 'Docker-Distribution-Api-Version' header.
+      ## The registry always sets this header.
+      map $upstream_http_docker_distribution_api_version $docker_distribution_api_version {
+        '' 'registry/2.0';
+      }
+
+      server {
+        listen 5000;
+        server_name 127.0.0.1;
+
+        # disable any limits to avoid HTTP 413 for large image uploads
+        client_max_body_size 0;
+
+        # required to avoid HTTP 411: see Issue #1486 (https://github.com/moby/moby/issues/1486)
+        chunked_transfer_encoding on;
+
+        location /v2/ {
+          # Do not allow connections from docker 1.5 and earlier
+          # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
+          if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*$" ) {
+            return 404;
+          }
+
+          ## If $docker_distribution_api_version is empty, the header is not added.
+          ## See the map directive above where this variable is defined.
+          add_header 'Docker-Distribution-Api-Version' $docker_distribution_api_version always;
+
+          proxy_pass                          http://docker-registry;
+          proxy_set_header  Host              $http_host;   # required for docker client's sake
+          proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+          proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+          proxy_set_header  X-Forwarded-Proto $scheme;
+          proxy_read_timeout                  900;
+        }
+      }
+    }

--- a/templates/localhost-proxy.yaml
+++ b/templates/localhost-proxy.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: localhost-proxy
+  namespace: registry
+  labels:
+    app: localhost-proxy
+spec:
+  selector:
+    matchLabels:
+      app: localhost-proxy
+  template:
+    metadata:
+      labels:
+        app: localhost-proxy
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.15.5@sha256:9ad0746d8f2ea6df3a17ba89eca40b48c47066dfab55a75e08e2b70fc80d929e
+        ports:
+        - containerPort: 5000
+          # On GKE with DaemonSet this enables pull from 127.0.0.1:5000 but not from localhost
+          hostPort: 5000
+        volumeMounts:
+        - name: etc-nginx
+          subPath: nginx.conf
+          mountPath: /etc/nginx/nginx.conf
+      volumes:
+      - name: etc-nginx
+        configMap:
+          name: localhost-proxy

--- a/templates/registry-alias-in-each-namespace.yaml
+++ b/templates/registry-alias-in-each-namespace.yaml
@@ -1,0 +1,7 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: knative-local-registry
+spec:
+  type: ExternalName
+  externalName: unauthenticated.registry.svc.cluster.local

--- a/templates/registry-cert-authz.yaml
+++ b/templates/registry-cert-authz.yaml
@@ -1,4 +1,3 @@
-# This RBAC isn't doing its thing
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,19 +10,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cert-requester-for-registry
 rules:
-- apiGroups: ["certificates.k8s.io"]
-  resources: ["certificatesigningrequests"]
-  resourceNames: ["private.registry", "registry-tls"]
-  verbs: ["get", "create"]
-- apiGroups: ["certificates.k8s.io"]
-  resources: ["certificatesigningrequests/registry-tls"]
-  verbs: ["get", "create"]
-- apiGroups: ["certificates.k8s.io"]
-  resources: ["certificatesigningrequests"]
-  verbs: ["get", "create"]
-- apiGroups: [""]
-  resources: ["certificatesigningrequests.certificates.k8s.io"]
-  verbs: ["get", "create"]
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/registry-cert-authz.yaml
+++ b/templates/registry-cert-authz.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: registry
+  name: cert-mgmt
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cert-requester-for-registry
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["create"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: registry
+  name: cert-secret-updater
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["registry-tls"]
+  verbs: ["update", "get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cert-request
+  namespace: registry
+subjects:
+- kind: ServiceAccount
+  name: cert-mgmt
+roleRef:
+  kind: ClusterRole
+  name: cert-requester-for-registry
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: cert-secret-updater
+  apiGroup: rbac.authorization.k8s.io

--- a/templates/registry-cert-authz.yaml
+++ b/templates/registry-cert-authz.yaml
@@ -1,3 +1,4 @@
+# This RBAC isn't doing its thing
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -12,7 +13,17 @@ metadata:
 rules:
 - apiGroups: ["certificates.k8s.io"]
   resources: ["certificatesigningrequests"]
-  verbs: ["create"]
+  resourceNames: ["private.registry", "registry-tls"]
+  verbs: ["get", "create"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests/registry-tls"]
+  verbs: ["get", "create"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["get", "create"]
+- apiGroups: [""]
+  resources: ["certificatesigningrequests.certificates.k8s.io"]
+  verbs: ["get", "create"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -25,18 +36,27 @@ rules:
   resourceNames: ["registry-tls"]
   verbs: ["update", "get"]
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cert-request
   namespace: registry
 subjects:
-- kind: ServiceAccount
-  name: cert-mgmt
+- kind: User
+  name: registry:cert-mgmt
 roleRef:
   kind: ClusterRole
   name: cert-requester-for-registry
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cert-secret-update
+  namespace: registry
+subjects:
+- kind: User
+  name: cert-mgmt
 roleRef:
   kind: Role
   name: cert-secret-updater

--- a/templates/registry-cert-authz.yaml
+++ b/templates/registry-cert-authz.yaml
@@ -31,10 +31,15 @@ metadata:
   namespace: registry
   name: cert-secret-updater
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  resourceNames: ["registry-tls"]
-  verbs: ["update", "get"]
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+  - patch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -42,8 +47,9 @@ metadata:
   name: cert-request
   namespace: registry
 subjects:
-- kind: User
-  name: registry:cert-mgmt
+- kind: ServiceAccount
+  name: cert-mgmt
+  namespace: registry
 roleRef:
   kind: ClusterRole
   name: cert-requester-for-registry
@@ -55,8 +61,9 @@ metadata:
   name: cert-secret-update
   namespace: registry
 subjects:
-- kind: User
+- kind: ServiceAccount
   name: cert-mgmt
+  namespace: registry
 roleRef:
   kind: Role
   name: cert-secret-updater

--- a/templates/registry-cert-job.yaml
+++ b/templates/registry-cert-job.yaml
@@ -11,13 +11,15 @@ spec:
       serviceAccount: cert-mgmt
       containers:
       - name: bash
-        image: solsson/kubectl-cfssl@sha256:bbfa272226b8d04fdbb2caeb724c115052d8ee2f9a1c1d5dc663e3d95aa4a146
-        imagePullPolicy: Never
+        image: solsson/kubectl-cfssl@sha256:ef611e1ddb4126a3377a075f2e91986950a30e01d837d0a7f8d96de031c230d7
         command:
-        - /bin/sh
+        - /bin/bash
         args:
-        - -c
+        - -cex
         - |
+          kubectl get secret registry-tls -o wide --ignore-not-found=true
+          kubectl get csr registry-tls -o wide --ignore-not-found=true
+
           cat <<EOF | cfssl genkey - | cfssljson -bare server
           {
             "hosts": [
@@ -33,7 +35,7 @@ spec:
           }
           EOF
 
-          cat <<EOF | tee server-csr.yaml | kubectl create -f - || cat server-csr.yaml
+          cat <<EOF | kubectl create -f -
           apiVersion: certificates.k8s.io/v1beta1
           kind: CertificateSigningRequest
           metadata:
@@ -48,19 +50,18 @@ spec:
             - server auth
           EOF
           
-          kubectl describe csr registry-tls || echo "\nFailed to create csr (RBAC issue probably)\n"
+          kubectl get csr registry-tls -o wide
 
-          while ! $(kubectl get csr registry-tls); do
+          until [ "$(kubectl get csr registry-tls -o jsonpath='{.status.conditions[0].type}')" == 'Approved' ]; do
             echo "\n"
             echo "Waiting for someone/somebot to run:"
-            echo "  kubectl certificate approve registry-tls"
-            echo "\n"
+            echo "kubectl certificate approve registry-tls"
             sleep 10
           done
 
           kubectl get csr registry-tls -o jsonpath='{.status.certificate}' | base64 --decode > server.crt
 
-          cat <<EOF | tee registry-tls-secret.yaml | kubectl create -f - || cat registry-tls-secret.yaml
+          cat <<EOF | kubectl apply -f -
           apiVersion: v1
           kind: Secret
           type: Opaque

--- a/templates/registry-cert-job.yaml
+++ b/templates/registry-cert-job.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccount: cert-mgmt
       containers:
       - name: bash
-        image: solsson/kubectl-cfssl@sha256:ef611e1ddb4126a3377a075f2e91986950a30e01d837d0a7f8d96de031c230d7
+        image: solsson/kubectl-cfssl@sha256:bbfa272226b8d04fdbb2caeb724c115052d8ee2f9a1c1d5dc663e3d95aa4a146
         command:
         - /bin/bash
         args:

--- a/templates/registry-cert-job.yaml
+++ b/templates/registry-cert-job.yaml
@@ -15,7 +15,7 @@ spec:
         command:
         - /bin/bash
         args:
-        - -cex
+        - -ce
         - |
           kubectl get secret registry-tls -o wide --ignore-not-found=true
           kubectl get csr registry-tls -o wide --ignore-not-found=true
@@ -53,7 +53,7 @@ spec:
           kubectl get csr registry-tls -o wide
 
           until [ "$(kubectl get csr registry-tls -o jsonpath='{.status.conditions[0].type}')" == 'Approved' ]; do
-            echo "\n"
+            echo ""
             echo "Waiting for someone/somebot to run:"
             echo "kubectl certificate approve registry-tls"
             sleep 10

--- a/templates/registry-cert-job.yaml
+++ b/templates/registry-cert-job.yaml
@@ -4,17 +4,19 @@ metadata:
   name: registry-cert-cluster-ca
   namespace: registry
 spec:
-  backoffLimit: 4
+  backoffLimit: 0
   template:
     spec:
       restartPolicy: Never
+      serviceAccount: cert-mgmt
       containers:
       - name: bash
-        image: debian:stretch-slim@sha256:40b4072ce18fabe32f357f7c9ec1d256d839b1b95bcdc1f9c910823c6c2932e9
+        image: solsson/kubectl-cfssl@sha256:bbfa272226b8d04fdbb2caeb724c115052d8ee2f9a1c1d5dc663e3d95aa4a146
+        imagePullPolicy: Never
         command:
         - /bin/sh
         args:
-        - cex
+        - -c
         - |
           cat <<EOF | cfssl genkey - | cfssljson -bare server
           {
@@ -23,7 +25,7 @@ spec:
               "authenticated.registry.svc.cluster.local",
               "knative-local-registry"
             ],
-            "CN": "registry.registry.svc.cluster.local",
+            "CN": "registry.svc.cluster.local",
             "key": {
               "algo": "ecdsa",
               "size": 256
@@ -31,11 +33,11 @@ spec:
           }
           EOF
 
-          cat <<EOF | kubectl create -f -
+          cat <<EOF | tee server-csr.yaml | kubectl create -f - || cat server-csr.yaml
           apiVersion: certificates.k8s.io/v1beta1
           kind: CertificateSigningRequest
           metadata:
-            name: private.registry
+            name: registry-tls
           spec:
             groups:
             - system:authenticated
@@ -46,7 +48,28 @@ spec:
             - server auth
           EOF
           
-          kubectl describe csr private.registry
+          kubectl describe csr registry-tls || echo "\nFailed to create csr (RBAC issue probably)\n"
 
-echo "Now someone/somebot with sufficient rights must run"
-echo "kubectl certificate approve private.registry"
+          while ! $(kubectl get csr registry-tls); do
+            echo "\n"
+            echo "Waiting for someone/somebot to run:"
+            echo "  kubectl certificate approve registry-tls"
+            echo "\n"
+            sleep 10
+          done
+
+          kubectl get csr registry-tls -o jsonpath='{.status.certificate}' | base64 --decode > server.crt
+
+          cat <<EOF | tee registry-tls-secret.yaml | kubectl create -f - || cat registry-tls-secret.yaml
+          apiVersion: v1
+          kind: Secret
+          type: Opaque
+          metadata:
+            name: registry-tls
+            namespace: registry
+          data:
+            tls.crt: $(cat server.crt | base64 | tr -d '\n')
+            tls.key: $(cat server-key.pem | base64 | tr -d '\n')
+          EOF
+
+          kubectl describe secret registry-tls || echo "\nFailed to create secret (RBAC issue probably)\n"

--- a/templates/registry-cert-job.yaml
+++ b/templates/registry-cert-job.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: registry-cert-cluster-ca
+  namespace: registry
+spec:
+  backoffLimit: 4
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: bash
+        image: debian:stretch-slim@sha256:40b4072ce18fabe32f357f7c9ec1d256d839b1b95bcdc1f9c910823c6c2932e9
+        command:
+        - /bin/sh
+        args:
+        - cex
+        - |
+          cat <<EOF | cfssl genkey - | cfssljson -bare server
+          {
+            "hosts": [
+              "unauthenticated.registry.svc.cluster.local",
+              "authenticated.registry.svc.cluster.local",
+              "knative-local-registry"
+            ],
+            "CN": "registry.registry.svc.cluster.local",
+            "key": {
+              "algo": "ecdsa",
+              "size": 256
+            }
+          }
+          EOF
+
+          cat <<EOF | kubectl create -f -
+          apiVersion: certificates.k8s.io/v1beta1
+          kind: CertificateSigningRequest
+          metadata:
+            name: private.registry
+          spec:
+            groups:
+            - system:authenticated
+            request: $(cat server.csr | base64 | tr -d '\n')
+            usages:
+            - digital signature
+            - key encipherment
+            - server auth
+          EOF
+          
+          kubectl describe csr private.registry
+
+echo "Now someone/somebot with sufficient rights must run"
+echo "kubectl certificate approve private.registry"

--- a/templates/registry-config.yaml
+++ b/templates/registry-config.yaml
@@ -1,0 +1,24 @@
+kind: ConfigMap
+metadata:
+  name: registry-config
+  namespace: registry
+apiVersion: v1
+data:
+  config.yml: |-
+    version: 0.1
+    log:
+      fields:
+        service: registry
+    storage:
+      cache:
+        blobdescriptor: inmemory
+      filesystem:
+        rootdirectory: /var/lib/registry
+    http:
+      headers:
+        X-Content-Type-Options: [nosniff]
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3

--- a/templates/registry-service-unauthenticated.yaml
+++ b/templates/registry-service-unauthenticated.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: unauthenticated
+  namespace: registry
+spec:
+  selector:
+    app: registry
+  ports:
+  - name: http
+    port: 80
+  - name: https
+    port: 443
+  - name: https-local
+    port: 5000
+    targetPort: 443

--- a/templates/registry.yaml
+++ b/templates/registry.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: registry
+  namespace: registry
+  labels:
+    app: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: podip-to-dns
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: busybox@sha256:cb63aa0641a885f54de20f61d152187419e8f6b159ed11a251a09d115fdff9bd
+        command:
+        - /bin/sh
+        args:
+        - -c
+        # Registry access could probably be consistent between knative and k8s using https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips
+        - |
+          echo "podIP is $POD_IP";
+          echo "How do we publish this to a DNS used by both nodes' docker and in-cluster?";
+          tail -f /dev/null;
+      - name: docker-v2
+        image: registry:2.6.2@sha256:672d519d7fd7bbc7a448d17956ebeefe225d5eb27509d8dc5ce67ecb4a0bce54
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80
+          name: registry
+          protocol: TCP
+        env:
+        - name: REGISTRY_HTTP_SECRET
+          value: TODO_GET_FROM_SECRET
+        - name: REGISTRY_HTTP_ADDR
+          value: 0.0.0.0:80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+            scheme: HTTP
+        volumeMounts:
+        - name: etc-registry
+          mountPath: /etc/docker/registry
+        - name: storage-temporary
+          mountPath: /var/lib/registry
+      - name: docker-v2-tls
+        image: registry:2.6.2@sha256:672d519d7fd7bbc7a448d17956ebeefe225d5eb27509d8dc5ce67ecb4a0bce54
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 443
+          name: registry
+          protocol: TCP
+        env:
+        - name: REGISTRY_HTTP_SECRET
+          value: hibHJByyPcMXppjgVY2mJVBMGVBDbk
+        - name: REGISTRY_HTTP_ADDR
+          value: 0.0.0.0:443
+        - name: REGISTRY_HTTP_TLS_CERTIFICATE
+          value: /certs/tls.crt
+        - name: REGISTRY_HTTP_TLS_KEY
+          value: /certs/tls.key
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 443
+            scheme: HTTPS
+        volumeMounts:
+        - name: etc-registry
+          mountPath: /etc/docker/registry
+        - name: certs
+          mountPath: /certs
+        - name: storage-temporary
+          mountPath: /var/lib/registry
+      volumes:
+      - name: etc-registry
+        configMap:
+          name: registry-config
+      - name: certs
+        secret:
+          secretName: registry-tls
+      - name: storage-temporary
+        emptyDir: {}


### PR DESCRIPTION
Our suggestion for https://github.com/knative/serving/issues/23 and as one kind of registry setup to verify https://github.com/knative/serving/issues/1996 against.

Note the manual setup step in the cert job (see its logs).

Also note that ./templates/registry-alias-in-each-namespace.yaml needs to be applied to the `knative-serving` namespace, in addition to any namespace that will host builds/servings.

This registry setup can also be protected with auth, using nginx, and exposed through Ingress. That's recommended for all clusters that have value SSL certificates for the domain, to avoid messing with TLS validation (https://github.com/triggermesh/knative-local-registry/blob/registry-templates/README.md#accepting-a-cluster-generated-cert-during-build). I will create an additional PR for the auth+ingress yaml.

I've tried alternatives to the patcing for cluster-CA support, like https://github.com/triggermesh/nodejs-runtime/commit/b8427512b9a95a52872a31500bd022204d9afb21, but found no compelling options.