### PR TITLE
Don't depend on a per-namespace alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,6 @@ kubectl -n kube-system set image deploy/coredns coredns=k8s.gcr.io/coredns:1.2.2
 ### On minikube
 
 Run `minikube ssh` followed by `echo "127.0.0.1 knative-local-registry" | sudo tee -a /etc/hosts`.
+
+You might also want `echo '127.0.0.1 unauthenticated.registry.svc.cluster.local' | sudo tee -a /etc/hosts`.
+See https://github.com/triggermesh/go-containerregistry/tree/registry-allow-port for why.

--- a/templates/localhost-proxy-config.yaml
+++ b/templates/localhost-proxy-config.yaml
@@ -9,6 +9,17 @@ data:
         worker_connections  10;
     }
 
+    stream {
+      upstream docker-registry-tls {
+        server unauthenticated:443;
+      }
+
+      server {
+        listen 443;
+        proxy_pass docker-registry-tls;
+      }
+    }
+
     http {
 
       upstream docker-registry {

--- a/templates/localhost-proxy-config.yaml
+++ b/templates/localhost-proxy-config.yaml
@@ -24,6 +24,7 @@ data:
       }
 
       server {
+        listen 80;
         listen 5000;
         server_name 127.0.0.1;
 

--- a/templates/localhost-proxy.yaml
+++ b/templates/localhost-proxy.yaml
@@ -21,6 +21,8 @@ spec:
         - containerPort: 5000
           # On GKE with DaemonSet this enables pull from 127.0.0.1:5000 but not from localhost
           hostPort: 5000
+        - containerPort: 80
+          hostPort: 80
         volumeMounts:
         - name: etc-nginx
           subPath: nginx.conf

--- a/templates/localhost-proxy.yaml
+++ b/templates/localhost-proxy.yaml
@@ -23,6 +23,8 @@ spec:
           hostPort: 5000
         - containerPort: 80
           hostPort: 80
+        - containerPort: 443
+          hostPort: 443
         volumeMounts:
         - name: etc-nginx
           subPath: nginx.conf


### PR DESCRIPTION
... and possibly not on a port number (#1) - but that's less of a priority because [ICP](https://medium.com/@zhimin.wen/explore-knative-build-on-on-premise-kubernetes-cluster-ibm-cloud-private-b0e94e59ba9d) for example seems to run `:8500`.

My main issue with the alias is that sometimes registry access is required by knative but it's difficult to know from which namespace. Also it's tricky to automate cluster setup.

A `.local` DNS name also meets the requirement that a public DNS wouln't resolve it. The name is long though, and we should probably not depend on `unauthenticated` because it's an implementation detail that is useful if you add authentication (manifests I've tested but that remain to make a PR from).