### PR TITLE
Upgrade Registry to 2.7.0

### DIFF
--- a/templates/registry.yaml
+++ b/templates/registry.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: docker-v2
-        image: registry:2.6.2@sha256:672d519d7fd7bbc7a448d17956ebeefe225d5eb27509d8dc5ce67ecb4a0bce54
+        image: registry:2.7.0@sha256:1cd9409a311350c3072fe510b52046f104416376c126a479cef9a4dfe692cf57
         resources:
           requests:
             cpu: 10m

--- a/templates/registry.yaml
+++ b/templates/registry.yaml
@@ -39,7 +39,7 @@ spec:
             memory: 16Mi
           limits:
             cpu: 100m
-            memory: 200Mi
+            memory: 100Mi
         ports:
         - containerPort: 80
           name: registry

--- a/test/kaniko-push-1gb.yaml
+++ b/test/kaniko-push-1gb.yaml
@@ -15,7 +15,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: registry-test-kaniko-push
+  name: registry-test-kaniko-push1gb
 spec:
   template:
     spec:
@@ -27,7 +27,7 @@ spec:
         - -ce
         - |
           date > ./timestamp;
-          echo "FROM scratch" > Dockerfile;
+          echo "FROM lambci/lambda@sha256:9f82e54b12a441cdf8dc92f5fc351148e91faa4b2c3b1af7bbf035da50c6f444" > Dockerfile;
           echo "COPY timestamp" >> /timestamp;
           /kaniko/executor --destination=knative.registry.svc.cluster.local/registrytest/kanikopush:latest
       restartPolicy: Never


### PR DESCRIPTION
Seems to solve #5. I've reduced the memory limit again. Let's see if we need to increase it when there's real load, or GCS persistence.